### PR TITLE
New functionalities to Image Viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2376,6 +2376,8 @@ print json_encode($res);
                                             <th scope="row">Optional Attributes</th>
                                                 <td>
                                                     <em>data-dragable</em>: set false to disable image dragging<br>
+                                                    <em>data-icon</em>: url of custom icon image<br>
+                                                    <em>data-button</em>: set false to disable destroy button<br>
                                                     <em>data-zoom</em>: set false to disable image zooming<br>
                                                     <em>data-zoom-max</em>: maximum zoom level of the image<br>
                                                     <em>data-zoom-step</em>: the zoom factor on mouse wheel
@@ -2386,12 +2388,12 @@ print json_encode($res);
                                     <div class="result-block">
                                         <h6>Result</h6>
                                         <div class="result">
-                                            <img data-type="image-viewer" data-notes='[{"x": "0.5","y": "0.5","note": "AFL Grand Final Trophy"},{"x": "0.322","y": "0.269","note": "<center><b>Brisbane Lions Flag</b><br/><img src=\"http://www.lions.com.au/static-resources/themes/brisbane/images/logo-brisbane.png\"/></center><a href=\"http://www.lions.com.au/\" target=\"blank\">The Brisbane Lions</a> is an <a href=\"http://en.wikipedia.org/wiki/Australian_rules_football\" target=\"blank\">Australian rules football club.</a>"},{"x": "0.824","y": "0.593","note": "Fluffy microphone"}]' src="https://waynegm.github.io/imgViewer2/images/test_image.jpg" alt="">
+                                            <img data-type="image-viewer" data-notes='[{"x": "0.5","y": "0.5","url": "https://weblabor.mx"},{"x": "0.322","y": "0.269","note": "<center><b>Brisbane Lions Flag</b><br/></center><a href=\"http://www.lions.com.au/\" target=\"blank\">The Brisbane Lions</a> is an <a href=\"http://en.wikipedia.org/wiki/Australian_rules_football\" target=\"blank\">Australian rules football club.</a>"},{"x": "0.824","y": "0.593","note": "Fluffy microphone"}]' src="https://waynegm.github.io/imgViewer2/images/test_image.jpg" width="100%" alt="">
                                         </div>
                                     </div>
                                     <div class="code-block">
                                         <h6>HTML Code</h6>
-                                        <code data-type="codeeditor" data-lang="html">&#x3C;img data-type=&quot;image-viewer&quot; data-notes='[{&quot;x&quot;: &quot;0.5&quot;,&quot;y&quot;: &quot;0.5&quot;,&quot;note&quot;: &quot;AFL Grand Final Trophy&quot;},{&quot;x&quot;: &quot;0.322&quot;,&quot;y&quot;: &quot;0.269&quot;,&quot;note&quot;: &quot;&lt;center&gt;&lt;b&gt;Brisbane Lions Flag&lt;/b&gt;&lt;br/&gt;&lt;img src=&quot;http://www.lions.com.au/static-resources/themes/brisbane/images/logo-brisbane.png&quot;/&gt;&lt;/center&gt;&lt;a href=&quot;http://www.lions.com.au/&quot; target=&quot;blank&quot;&gt;The Brisbane Lions&lt;/a&gt; is an &lt;a href=&quot;http://en.wikipedia.org/wiki/Australian_rules_football&quot; target=&quot;blank&quot;&gt;Australian rules football club.&lt;/a&gt;&quot;},{&quot;x&quot;: &quot;0.824&quot;,&quot;y&quot;: &quot;0.593&quot;,&quot;note&quot;: &quot;Fluffy microphone&quot;}]' src=&quot;https://waynegm.github.io/imgViewer2/images/test_image.jpg&quot; src=&quot;https://waynegm.github.io/imgViewer2/images/test_image.jpg&quot; alt=&quot;&quot;&#x3E;</code>
+                                        <code data-type="codeeditor" data-lang="html">&#x3C;img data-type=&quot;image-viewer&quot; data-notes='[{&quot;x&quot;: &quot;0.5&quot;,&quot;y&quot;: &quot;0.5&quot;,&quot;url&quot;: &quot;https://weblabor.mx&quot;},{&quot;x&quot;: &quot;0.322&quot;,&quot;y&quot;: &quot;0.269&quot;,&quot;note&quot;: &quot;&lt;center&gt;&lt;b&gt;Brisbane Lions Flag&lt;/b&gt;&lt;br/&gt;&lt;/center&gt;&lt;a href=&quot;http://www.lions.com.au/&quot; target=&quot;blank&quot;&gt;The Brisbane Lions&lt;/a&gt; is an &lt;a href=&quot;http://en.wikipedia.org/wiki/Australian_rules_football&quot; target=&quot;blank&quot;&gt;Australian rules football club.&lt;/a&gt;&quot;},{&quot;x&quot;: &quot;0.824&quot;,&quot;y&quot;: &quot;0.593&quot;,&quot;note&quot;: &quot;Fluffy microphone&quot;}]' src=&quot;https://waynegm.github.io/imgViewer2/images/test_image.jpg&quot; src=&quot;https://waynegm.github.io/imgViewer2/images/test_image.jpg&quot; width=&quot;100&percnt;&quot; alt=&quot;&quot;&#x3E;</code>
                                     </div>
                                 </div>
                             </section>


### PR DESCRIPTION
- Adding `url: "https://example.com"` to the `data-notes` now overrides the note and it takes directly you to the site when clicking the marker.
- You can disable the destroy button by using `data-button="false"`
- When `data-zoom:"false"` the controls now hide
- You can change the marker icon by providing an url with `data-icon="https://mycdn.com/myicon.jpg"`
