### PR TITLE
Added vimeo list video pattern on popup

### DIFF
--- a/library/script-new.js
+++ b/library/script-new.js
@@ -901,7 +901,34 @@ function EasyJsLibrary() {
                     });
                 }
                 item.magnificPopup({
-                    type: type
+                    type: type,
+                    iframe: {
+
+                        patterns: {
+                            vimeo: {
+                                index: "vimeo.com/",
+                                id: function (url) {
+                                    const regex = /^(?:http:\/\/|https:\/\/|\/\/)?vimeo.com\/(\w+)\/?(?:(\w+)\/?)?$/;
+                                    const match = url.match(regex);
+
+                                    let id = "";
+                                    let separator = '?';
+
+                                    if (match.length < 2) return;
+
+                                    if (match.length == 2) {
+                                        id = match[1];
+                                    } else if (match.length == 3) {
+                                        separator = "&";
+                                        id = `${match[1]}?h=${match[2]}`
+                                    }
+
+                                    return `${id}${separator}autoplay=1`
+                                },
+                                src: '//player.vimeo.com/video/%id%'
+                            }
+                        }
+                    }
                 });
                 var automatic = item.attr("data-automatic");
                 if (typeof automatic !== typeof undefined && automatic !== false) {


### PR DESCRIPTION
Magnific popup supports by default only [one format of urls](https://dimsemenov.com/plugins/magnific-popup/documentation.html#iframe-type). So there was a problem when using a video from a list with url of `https://vimeo.com/LIST_ID/VIDEO_ID` since it was generating `https://player.vimeo.com/video/VIDEO_ID?autoplay=1` instead of the correct one `https://player.vimeo.com/video/LIST_ID?h=VIDEO_ID&autoplay=1`